### PR TITLE
Fix yesterday energy sensor & frequency precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The integration provides multiple sensor entities organized by importance:
 - **Alarm Codes (SAL)** - Current alarm/error codes (bitmask)
 
 #### Production History (Disabled by Default)
-- **Energy Yesterday (KDL)** - Previous day's energy production in kWh
+- **Energy Yesterday (KLD)** - Previous day's energy production in kWh
 - **Energy Last Month (KLM)** - Previous month's energy production in kWh
 - **Energy Last Year (KLY)** - Previous year's energy production in kWh
 - **Relative Power (PRL)** - Current output as % of rated power

--- a/custom_components/solarmax/const.py
+++ b/custom_components/solarmax/const.py
@@ -559,9 +559,9 @@ SENSOR_TYPES = {
         "entity_category": None,  # Main measurement
         "enabled_by_default": True,
     },
-    "KDL": {
+    "KLD": {
         "name": "Energy Yesterday",
-        "translation_key": "kdl",
+        "translation_key": "kld",
         "unit": "kWh",
         "device_class": "energy",
         "state_class": "measurement",
@@ -664,6 +664,7 @@ SENSOR_TYPES = {
         "icon": "mdi:sine-wave",
         "entity_category": EntityCategory.DIAGNOSTIC,
         "enabled_by_default": False,
+        "suggested_display_precision": 2,
     },
     "ULH": {
         "name": "Grid Voltage Upper Limit",
@@ -694,6 +695,7 @@ SENSOR_TYPES = {
         "icon": "mdi:sine-wave",
         "entity_category": EntityCategory.DIAGNOSTIC,
         "enabled_by_default": False,
+        "suggested_display_precision": 2,
     },
     "TNL": {
         "name": "Grid Frequency Lower Limit",
@@ -704,6 +706,7 @@ SENSOR_TYPES = {
         "icon": "mdi:sine-wave",
         "entity_category": EntityCategory.DIAGNOSTIC,
         "enabled_by_default": False,
+        "suggested_display_precision": 2,
     },
     "SAL": {
         "name": "Alarm Codes",

--- a/custom_components/solarmax/manifest.json
+++ b/custom_components/solarmax/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/oschick/solarmax-ha-integration/issues",
   "requirements": [],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/custom_components/solarmax/sensor.py
+++ b/custom_components/solarmax/sensor.py
@@ -143,6 +143,10 @@ class SolarmaxSensor(CoordinatorEntity[SolarmaxCoordinator], SensorEntity):
             self._attr_state_class = sensor_config["state_class"]
         if "icon" in sensor_config:
             self._attr_icon = sensor_config["icon"]
+        if "suggested_display_precision" in sensor_config:
+            self._attr_suggested_display_precision = sensor_config[
+                "suggested_display_precision"
+            ]
 
         # Device info - model is already resolved since async_config_entry_first_refresh
         # runs before sensor platform setup

--- a/custom_components/solarmax/solarmax_api.py
+++ b/custom_components/solarmax/solarmax_api.py
@@ -63,7 +63,7 @@ PROTO_ERROR_INVALID_PORT = "IPN"  # Invalid port number
 # Spannung_2:         0.1 V/digit    (UDC, UL1, UL2, UL3, UD01, UD02, UD03)
 # Strom_positiv_2:    0.01 A/digit   (IDC, ID01, ID02, ID03, IL1, IL2, IL3)
 # Leistung:           0.5 W/digit    (PAC, PDC, PD01, PD02, PD03, PIN)
-# Energie_1:          0.1 kWh/digit  (KDY, KDL)
+# Energie_1:          0.1 kWh/digit  (KDY, KLD)
 # Energie_2:          1 kWh/digit    (KMT, KYR, KT0, KLM, KLY)
 # Frequenz:           0.1 Hz/digit   (TNF)
 # Temperatur_positiv: 1 °C/digit     (TKK)
@@ -123,7 +123,7 @@ FIELD_MAP_INVERTER = {
     "ID01": "DC_Current_String_1",  # Strom_positiv_2 (0.01 A/digit)
     "ID02": "DC_Current_String_2",  # Strom_positiv_2 (0.01 A/digit)
     "ID03": "DC_Current_String_3",  # Strom_positiv_2 (0.01 A/digit)
-    "KDL": "Energy_Yesterday",  # Energie_1 (0.1 kWh/digit)
+    "KLD": "Energy_Yesterday",  # Energie_1 (0.1 kWh/digit)
     "KLM": "Energy_Last_Month",  # Energie_2 (1 kWh/digit)
     "KLY": "Energy_Last_Year",  # Energie_2 (1 kWh/digit)
     "TNF": "Grid_Frequency",  # Frequenz (0.1 Hz/digit)
@@ -433,7 +433,7 @@ class SolarmaxAPI:
         ):
             # Spannung_2: resolution 0.1 V/digit
             return value / 10.0
-        elif field in ("KDY", "KDL"):
+        elif field in ("KDY", "KLD"):
             # Energie_1: resolution 0.1 kWh/digit
             return value / 10.0
         elif field in ("IDC", "ID01", "ID02", "ID03", "IL1", "IL2", "IL3"):

--- a/custom_components/solarmax/strings.json
+++ b/custom_components/solarmax/strings.json
@@ -138,7 +138,7 @@
       "kt0": {
         "name": "Energy Total"
       },
-      "kdl": {
+      "kld": {
         "name": "Energy Yesterday"
       },
       "klm": {

--- a/custom_components/solarmax/translations/en.json
+++ b/custom_components/solarmax/translations/en.json
@@ -138,7 +138,7 @@
       "kt0": {
         "name": "Energy Total"
       },
-      "kdl": {
+      "kld": {
         "name": "Energy Yesterday"
       },
       "klm": {

--- a/custom_components/solarmax/translations/fr.json
+++ b/custom_components/solarmax/translations/fr.json
@@ -136,7 +136,7 @@
       "kt0": {
         "name": "Énergie totale"
       },
-      "kdl": {
+      "kld": {
         "name": "Énergie d'hier"
       },
       "klm": {

--- a/tools/inverter_emulator.py
+++ b/tools/inverter_emulator.py
@@ -99,7 +99,7 @@ class InverterState:
     id03: int = 0  # DC Current String 3: 0A
 
     # Energy history
-    kdl: int = 72  # Energy Yesterday: 72/10 = 7.2 kWh
+    kld: int = 72  # Energy Yesterday: 72/10 = 7.2 kWh
     klm: int = 320  # Energy Last Month: 320 kWh
     kly: int = 3800  # Energy Last Year: 3800 kWh
 
@@ -151,7 +151,7 @@ def get_scenario_state(scenario: str) -> InverterState:
             kmt=350,
             kyr=4200,
             kt0=28500,
-            kdl=72,
+            kld=72,
             klm=320,
             kly=3800,
             tkk=18,
@@ -190,7 +190,7 @@ def get_scenario_state(scenario: str) -> InverterState:
             kmt=350,
             kyr=4200,
             kt0=28500,
-            kdl=72,
+            kld=72,
             klm=320,
             kly=3800,
             tkk=22,
@@ -229,7 +229,7 @@ def get_scenario_state(scenario: str) -> InverterState:
             kmt=350,
             kyr=4200,
             kt0=28500,
-            kdl=72,
+            kld=72,
             klm=320,
             kly=3800,
             tkk=38,
@@ -267,7 +267,7 @@ def get_scenario_state(scenario: str) -> InverterState:
             kmt=350,
             kyr=4200,
             kt0=28500,
-            kdl=72,
+            kld=72,
             klm=320,
             kly=3800,
             tkk=45,
@@ -305,7 +305,7 @@ def get_scenario_state(scenario: str) -> InverterState:
             kmt=1200,
             kyr=4800,
             kt0=29000,
-            kdl=240,
+            kld=240,
             klm=1100,
             kly=4500,
             tkk=58,
@@ -343,7 +343,7 @@ def get_scenario_state(scenario: str) -> InverterState:
             kmt=350,
             kyr=4200,
             kt0=28500,
-            kdl=72,
+            kld=72,
             klm=320,
             kly=3800,
             tkk=25,
@@ -624,7 +624,7 @@ def interactive_loop(emulator: SolarmaxEmulator):
             print(f"  PRL (rel power): {s.prl}%")
             print(f"  PIN (installed): {s.pin} raw -> {s.pin / 2}W")
             print(f"  KDY (day):       {s.kdy} raw -> {s.kdy / 10} kWh")
-            print(f"  KDL (yesterday): {s.kdl} raw -> {s.kdl / 10} kWh")
+            print(f"  kld (yesterday): {s.kld} raw -> {s.kld / 10} kWh")
             print(f"  KT0 (total):     {s.kt0} kWh")
             print(f"  Noise: {'on' if s.add_noise else 'off'}")
             print("")


### PR DESCRIPTION
## Description
### Fixed
- Fixed incorrect Energy Yesterday sensor key (KDL → KLD). Thanks @olabaie
- Fixed suggested precision for frequency sensors (two decimal places). Thanks @olabaie

## Type of change
Please delete options that are not relevant:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

